### PR TITLE
Add local video clip player

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Clipper
+
+A simple local web app to browse randomly generated video clips from a directory. It analyzes each video, splits them into 30 second segments and stores the metadata in a local SQLite database.
+
+## Usage
+1. Place your video files inside the `videos/` directory.
+2. Run the server with `node index.js`.
+3. Open `http://localhost:3000` in your browser.
+
+Watch clips and skip with the large button. The app records how long each clip was watched and adjusts the rating. Highly rated clips are more likely to play while poorly rated ones are skipped.
+
+`ffmpeg` and `ffprobe` must be installed on your system for clip extraction.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const app = express();
+app.use(express.static('public'));
+
+const DB_FILE = 'clips.db';
+const VIDEOS_DIR = path.join(__dirname, 'videos');
+const CLIPS_TABLE = `CREATE TABLE IF NOT EXISTS clips (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  file TEXT,
+  start REAL,
+  end REAL,
+  rating INTEGER DEFAULT 0,
+  views INTEGER DEFAULT 0
+)`;
+const db = new sqlite3.Database(DB_FILE);
+db.serialize(() => {
+  db.run(CLIPS_TABLE);
+});
+
+function analyzeVideos() {
+  const files = fs.readdirSync(VIDEOS_DIR);
+  files.forEach(file => {
+    const ext = path.extname(file).toLowerCase();
+    if (!['.mp4', '.mov', '.webm', '.mkv'].includes(ext)) return;
+    const filePath = path.join(VIDEOS_DIR, file);
+    // use ffprobe to get duration
+    const probe = spawn('ffprobe', ['-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', filePath]);
+    let data = '';
+    probe.stdout.on('data', chunk => data += chunk);
+    probe.on('close', () => {
+      const duration = parseFloat(data);
+      if (isNaN(duration)) return;
+      const clipCount = Math.ceil(duration / 30);
+      db.serialize(() => {
+        for (let i = 0; i < clipCount; i++) {
+          const start = i * 30;
+          const end = Math.min((i + 1) * 30, duration);
+          db.run('INSERT INTO clips (file, start, end) VALUES (?, ?, ?)', [filePath, start, end]);
+        }
+      });
+    });
+  });
+}
+
+function pickClip(callback) {
+  db.all('SELECT * FROM clips', (err, rows) => {
+    if (err) return callback(err);
+    if (rows.length === 0) return callback(new Error('No clips'));
+    // weight clips by rating+1 to prioritize high rated and new clips
+    const weighted = [];
+    rows.forEach(row => {
+      if (row.rating < -5) return; // skip badly rated
+      const weight = Math.max(1, row.rating + 1);
+      for (let i = 0; i < weight; i++) weighted.push(row);
+    });
+    const clip = weighted[Math.floor(Math.random() * weighted.length)];
+    callback(null, clip);
+  });
+}
+
+app.get('/random', (req, res) => {
+  pickClip((err, clip) => {
+    if (err) return res.status(500).send(err.toString());
+    res.json(clip);
+  });
+});
+
+app.get('/clip/:id', (req, res) => {
+  const id = req.params.id;
+  db.get('SELECT * FROM clips WHERE id = ?', [id], (err, row) => {
+    if (err || !row) return res.status(404).end();
+    const args = ['-ss', row.start.toString(), '-to', row.end.toString(), '-i', row.file, '-f', 'mp4', '-movflags', 'frag_keyframe+empty_moov', 'pipe:1'];
+    const ff = spawn('ffmpeg', args);
+    res.type('video/mp4');
+    ff.stdout.pipe(res);
+  });
+});
+
+app.post('/watch/:id', express.json(), (req, res) => {
+  const id = req.params.id;
+  const watched = req.body.watched || 0;
+  const rating = watched > 25 ? 1 : watched < 5 ? -1 : 0;
+  db.run('UPDATE clips SET views = views + 1, rating = rating + ? WHERE id = ?', [rating, id]);
+  res.end();
+});
+
+const PORT = 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+  analyzeVideos();
+});

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
   },
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "Local video clip viewer",
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Clip Player</title>
+  <style>
+    body { text-align: center; margin-top: 50px; font-family: Arial, sans-serif; }
+    button { font-size: 2em; padding: 20px 40px; margin: 20px; }
+    video { width: 80%; height: auto; }
+  </style>
+</head>
+<body>
+  <video id="player" controls></video>
+  <div>
+    <button id="play">Play Random</button>
+    <button id="skip">Skip</button>
+  </div>
+<script>
+let currentId = null;
+const player = document.getElementById('player');
+
+async function loadRandom() {
+  const res = await fetch('/random');
+  const clip = await res.json();
+  currentId = clip.id;
+  player.src = `/clip/${clip.id}`;
+  player.play();
+}
+
+document.getElementById('play').onclick = loadRandom;
+
+document.getElementById('skip').onclick = () => {
+  fetch(`/watch/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({watched: player.currentTime})});
+  loadRandom();
+};
+
+player.onended = () => {
+  fetch(`/watch/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({watched: player.duration})});
+  loadRandom();
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a simple Express/SQLite app
- analyze videos and expose endpoints to play random clips
- basic HTML frontend to play/skip clips
- document usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68577c3a20448325a8b54adca439a2c5