### PR TITLE
Make video path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple local web app to browse randomly generated video clips from a directory
 
 ## Usage
 1. Install dependencies with `npm install`.
-2. Place your video files inside the `videos/` directory (the folder will be created automatically on first run).
+2. Place your video files inside the `videos/` directory or set the `VIDEOS_DIR` environment variable to a custom path (the folder will be created automatically on first run).
 3. Start the server with `npm start`.
 4. Open `http://localhost:3000` in your browser.
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ const app = express();
 app.use(express.static('public'));
 
 const DB_FILE = 'clips.db';
-const VIDEOS_DIR = path.join(__dirname, 'videos');
+const VIDEOS_DIR = process.env.VIDEOS_DIR
+  ? path.resolve(process.env.VIDEOS_DIR)
+  : path.join(__dirname, 'videos');
 
 // ensure the videos directory exists so readdirSync doesn't throw
 if (!fs.existsSync(VIDEOS_DIR)) {


### PR DESCRIPTION
## Summary
- allow configuration of video directory via `VIDEOS_DIR` environment variable
- document the new option in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68577f8018e48325813fd25d1e40226a