### PR TITLE
Add ignore, rating, and favorite controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ A simple local web app to browse randomly generated video clips from a directory
 3. Start the server with `npm start`.
 4. Open `http://localhost:3000` in your browser.
 
-Watch clips and skip with the large button. The app records how long each clip was watched and adjusts the rating. Highly rated clips are more likely to play while poorly rated ones are skipped.
+Watch clips and skip with the large button. You can also **ignore** clips which removes them from the database, give a **thumbs up** or **thumbs down** once per clip to heavily adjust its score, and **favorite** clips for later. The app records how long each clip was watched and adjusts the rating. Highly rated clips are more likely to play while poorly rated ones are skipped.
 
 `ffmpeg` and `ffprobe` must be installed on your system for clip extraction.

--- a/public/index.html
+++ b/public/index.html
@@ -30,10 +30,16 @@
   <div>
     <button id="play">Play Random</button>
     <button id="skip">Skip</button>
+    <button id="ignore">Ignore</button>
+    <button id="like">👍</button>
+    <button id="dislike">👎</button>
+    <button id="favorite">⭐</button>
   </div>
 <script>
 let currentId = null;
 const player = document.getElementById('player');
+let hasRated = false;
+let ratingDelta = 0;
 
 async function loadRandom() {
   const res = await fetch('/random');
@@ -41,17 +47,45 @@ async function loadRandom() {
   currentId = clip.id;
   player.src = `/clip/${clip.id}`;
   player.play();
+  hasRated = false;
+  ratingDelta = 0;
 }
 
 document.getElementById('play').onclick = loadRandom;
 
 document.getElementById('skip').onclick = () => {
   fetch(`/watch/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({watched: player.currentTime})});
+  if (ratingDelta !== 0) {
+    fetch(`/rate/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({delta: ratingDelta})});
+  }
   loadRandom();
+};
+
+document.getElementById('ignore').onclick = () => {
+  fetch(`/ignore/${currentId}`, {method: 'POST'}).then(loadRandom);
+};
+
+document.getElementById('like').onclick = () => {
+  if (hasRated) return;
+  hasRated = true;
+  ratingDelta = 1;
+};
+
+document.getElementById('dislike').onclick = () => {
+  if (hasRated) return;
+  hasRated = true;
+  ratingDelta = -1;
+};
+
+document.getElementById('favorite').onclick = () => {
+  fetch(`/favorite/${currentId}`, {method: 'POST'});
 };
 
 player.onended = () => {
   fetch(`/watch/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({watched: player.duration})});
+  if (ratingDelta !== 0) {
+    fetch(`/rate/${currentId}`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({delta: ratingDelta})});
+  }
   loadRandom();
 };
 </script>


### PR DESCRIPTION
## Summary
- enable favouriting by storing a `favorite` flag
- allow removing clips entirely with `/ignore/:id`
- add `/rate/:id` endpoint for thumbs up/down boosts
- support ignore/like/dislike/favorite buttons in the UI
- document the new features

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68577fc437d88325ad29888ab2ddeb13