### PR TITLE
Add configurable video path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Next.js based web app to browse randomly generated video clips from a director
 
 ## Usage
 1. Install dependencies with `npm install`.
-2. Place your video files inside the `videos/` directory (the folder will be created automatically on first run).
+2. Configure the video directory from the **Settings** page or by editing `config.json`. The default location is `videos/` inside the project.
 3. Run the development server with `npm run dev` and open `http://localhost:3000` in your browser.
 4. For production build run `npm run build` followed by `npm start`.
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "videosDir": "videos"
+}

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,19 +1,20 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { db, VIDEOS_DIR } = require('./db');
+const { db, getVideosDir } = require('./db');
 
-let analyzed = false;
+let analyzedDir = null;
 
 function analyzeVideos() {
-  if (analyzed) return;
-  analyzed = true;
+  const videosDir = getVideosDir();
+  if (analyzedDir === videosDir) return;
+  analyzedDir = videosDir;
 
-  const files = fs.readdirSync(VIDEOS_DIR);
+  const files = fs.readdirSync(videosDir);
   files.forEach(file => {
     const ext = path.extname(file).toLowerCase();
     if (!['.mp4', '.mov', '.webm', '.mkv'].includes(ext)) return;
-    const filePath = path.join(VIDEOS_DIR, file);
+    const filePath = path.join(videosDir, file);
 
     const probe = spawn('ffprobe', ['-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', filePath]);
     let data = '';

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILE = path.join(process.cwd(), 'config.json');
+const DEFAULT_DIR = path.join(process.cwd(), 'videos');
+
+function loadConfig() {
+  try {
+    const data = fs.readFileSync(CONFIG_FILE, 'utf8');
+    const json = JSON.parse(data);
+    return { videosDir: json.videosDir || DEFAULT_DIR };
+  } catch (e) {
+    return { videosDir: DEFAULT_DIR };
+  }
+}
+
+function saveConfig(config) {
+  const data = { videosDir: config.videosDir || DEFAULT_DIR };
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2));
+}
+
+module.exports = { loadConfig, saveConfig };

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,13 +1,19 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
+const { loadConfig } = require('./config');
 
 const DB_FILE = path.join(process.cwd(), 'clips.db');
-const VIDEOS_DIR = path.join(process.cwd(), 'videos');
-
-if (!fs.existsSync(VIDEOS_DIR)) {
-  fs.mkdirSync(VIDEOS_DIR, { recursive: true });
+function getVideosDir() {
+  const { videosDir } = loadConfig();
+  if (!fs.existsSync(videosDir)) {
+    fs.mkdirSync(videosDir, { recursive: true });
+  }
+  return videosDir;
 }
+
+// ensure directory exists on first use
+getVideosDir();
 
 const db = new sqlite3.Database(DB_FILE);
 
@@ -22,4 +28,4 @@ db.serialize(() => {
   )`);
 });
 
-module.exports = { db, VIDEOS_DIR };
+module.exports = { db, getVideosDir };

--- a/pages/api/config.js
+++ b/pages/api/config.js
@@ -1,0 +1,19 @@
+import { loadConfig, saveConfig } from '../../lib/config';
+import { analyzeVideos } from '../../lib/analyze';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    const config = loadConfig();
+    return res.status(200).json(config);
+  }
+  if (req.method === 'POST') {
+    const { videosDir } = req.body || {};
+    if (!videosDir || typeof videosDir !== 'string') {
+      return res.status(400).json({ error: 'Invalid videosDir' });
+    }
+    saveConfig({ videosDir });
+    analyzeVideos();
+    return res.status(200).json({ videosDir });
+  }
+  res.status(405).end();
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import Link from 'next/link';
 
 export default function Home() {
   const videoRef = useRef(null);
@@ -38,6 +39,9 @@ export default function Home() {
       <div>
         <button onClick={loadRandom} style={{ fontSize: '2em', margin: 20 }}>Play Random</button>
         <button onClick={handleSkip} style={{ fontSize: '2em', margin: 20 }}>Skip</button>
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <Link href="/settings">Settings</Link>
       </div>
     </div>
   );

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Settings() {
+  const [videosDir, setVideosDir] = useState('');
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      const res = await fetch('/api/config');
+      if (res.ok) {
+        const data = await res.json();
+        setVideosDir(data.videosDir || '');
+      }
+    };
+    fetchConfig();
+  }, []);
+
+  const save = async () => {
+    await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videosDir })
+    });
+  };
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: 50 }}>
+      <h1>Settings</h1>
+      <div>
+        <input
+          type="text"
+          value={videosDir}
+          onChange={e => setVideosDir(e.target.value)}
+          style={{ width: '60%' }}
+        />
+        <button onClick={save} style={{ marginLeft: 10 }}>Save</button>
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <Link href="/">Home</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow updating the video directory via API and settings page
- store configuration in `config.json`
- update database and analyzer to read the path dynamically
- document new behaviour in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68577fece1588325974b639eacaa0802