### PR TITLE
Support web videos via video manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Clipper
 
-A Next.js based web app to browse randomly generated video clips from a directory. It analyzes each video, splits them into 30 second segments and stores the metadata in a local SQLite database.
+A Next.js based web app to browse randomly generated video clips from a directory or the web. Local videos are analyzed and split into 30 second segments while web clips can be added directly. All metadata is stored in a local SQLite database.
 
 ## Usage
 1. Install dependencies with `npm install`.
-2. Place your video files inside the `videos/` directory (the folder will be created automatically on first run).
+2. Place your video files inside the `videos/` directory (the folder will be created automatically on first run) or register a web URL using the video manager.
 3. Run the development server with `npm run dev` and open `http://localhost:3000` in your browser.
 4. For production build run `npm run build` followed by `npm start`.
+
+Web clips can be added programmatically via `lib/videoManager.js` using `addWebVideo(url)`.
 
 Watch clips and skip with the large button. The app records how long each clip was watched and adjusts the rating. Highly rated clips are more likely to play while poorly rated ones are skipped.
 

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -26,7 +26,7 @@ function analyzeVideos() {
         for (let i = 0; i < clipCount; i++) {
           const start = i * 30;
           const end = Math.min((i + 1) * 30, duration);
-          db.run('INSERT INTO clips (file, start, end) VALUES (?, ?, ?)', [filePath, start, end]);
+          db.run('INSERT INTO clips (file, start, end, type) VALUES (?, ?, ?, ?)', [filePath, start, end, 'local']);
         }
       });
     });

--- a/lib/db.js
+++ b/lib/db.js
@@ -18,7 +18,8 @@ db.serialize(() => {
     start REAL,
     end REAL,
     rating INTEGER DEFAULT 0,
-    views INTEGER DEFAULT 0
+    views INTEGER DEFAULT 0,
+    type TEXT DEFAULT 'local'
   )`);
 });
 

--- a/lib/videoManager.js
+++ b/lib/videoManager.js
@@ -1,0 +1,33 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { db, VIDEOS_DIR } = require('./db');
+
+function addWebVideo(url) {
+  db.run('INSERT INTO clips (file, start, end, type) VALUES (?, 0, 0, ?)', [url, 'web']);
+}
+
+function addLocalVideo(file) {
+  const ext = path.extname(file).toLowerCase();
+  if (!['.mp4', '.mov', '.webm', '.mkv'].includes(ext)) return;
+  const filePath = path.join(VIDEOS_DIR, file);
+  if (!fs.existsSync(filePath)) return;
+
+  const probe = spawn('ffprobe', ['-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', filePath]);
+  let data = '';
+  probe.stdout.on('data', chunk => data += chunk);
+  probe.on('close', () => {
+    const duration = parseFloat(data);
+    if (isNaN(duration)) return;
+    const clipCount = Math.ceil(duration / 30);
+    db.serialize(() => {
+      for (let i = 0; i < clipCount; i++) {
+        const start = i * 30;
+        const end = Math.min((i + 1) * 30, duration);
+        db.run('INSERT INTO clips (file, start, end, type) VALUES (?, ?, ?, ?)', [filePath, start, end, 'local']);
+      }
+    });
+  });
+}
+
+module.exports = { addWebVideo, addLocalVideo };


### PR DESCRIPTION
## Summary
- allow clips table to store a `type`
- store `local` clips when analyzing video files
- add a new `videoManager` module for registering web videos
- document how to use the new manager and add web clips

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857802dbc5083259401d76dccaaf1e2