### PR TITLE
Add video manager page

### DIFF
--- a/pages/api/clips.js
+++ b/pages/api/clips.js
@@ -1,0 +1,11 @@
+import { db } from '../../lib/db';
+import { analyzeVideos } from '../../lib/analyze';
+
+export default function handler(req, res) {
+  analyzeVideos();
+  db.all('SELECT id FROM clips ORDER BY id', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.toString() });
+    const clips = rows.map(r => r.id);
+    res.status(200).json({ clips });
+  });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -85,6 +85,8 @@ export default function Home() {
       </div>
       <div style={{ marginTop: 20 }}>
         <Link href="/settings">Settings</Link>
+        {' | '}
+        <Link href="/manager">Video Manager</Link>
       </div>
     </div>
   );

--- a/pages/manager.js
+++ b/pages/manager.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Manager() {
+  const [clips, setClips] = useState([]);
+
+  useEffect(() => {
+    const fetchClips = async () => {
+      const res = await fetch('/api/clips');
+      if (res.ok) {
+        const data = await res.json();
+        setClips(data.clips || []);
+      }
+    };
+    fetchClips();
+  }, []);
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: 20 }}>
+      <h1>Video Manager</h1>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          gap: 10,
+          margin: 20
+        }}
+      >
+        {clips.map(id => (
+          <video key={id} src={`/api/clip/${id}`} style={{ width: '100%' }} controls />
+        ))}
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <Link href="/">Home</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add REST API to list video clips
- create video manager page with grid layout
- link to video manager from home page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857861ad5608325aa770d040dac33c3